### PR TITLE
Feature/meal planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,40 @@ Welcome to the Macro & Fitness Tracker with Meal Prepper App! This is a full-sta
 
 **Disclaimer**: Android SDK or Xcode is needed for the phone to pop up
 
+
+## Environment configuration (do NOT commit real keys)
+
+Frontend (Expo):
+- Create `frontend/.env`:
+  ```
+  EXPO_PUBLIC_API_URL=http://YOUR_MACHINE_IP:5000
+  ```
+  Replace `YOUR_MACHINE_IP` with the LAN IP your device can reach. Restart Expo after changes.
+
+Backend:
+- Create `backend/.env`:
+  ```
+  OPENAI_API_KEY=sk-...
+  PORT=5000
+  # Optional FatSecret (enables nutrition lookup on server)
+  FATSECRET_CLIENT_ID=
+  FATSECRET_CLIENT_SECRET=
+  ```
+- The repo’s `.gitignore` already excludes `frontend/.env` and `backend/.env`.
+
+## Branch, push and merge
+
+```bash
+# from repo root
+git checkout feature/meal-planner
+git status
+# review changes, ensure no .env files are staged
+git push -u origin feature/meal-planner
+
+# merge to main (locally)
+git checkout main
+git pull origin main
+git merge --no-ff feature/meal-planner
+git push origin main
+```
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "prepandcount-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "NODE_ENV=development node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "openai": "^4.55.0"
+  }
+}
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -87,7 +87,7 @@ function computeTargets({ fitnessGoal, gender, weightKg, heightCm, age, activity
 function buildPrompt(p) {
   const { fitnessGoal, heightCm, weightKg, age, gender, activityLevel, calorieGoal, macros, likes, dislikes, days = 7 } = p;
   return `
-You are a certified nutritionist. Based on the following user information, create a detailed 7-day meal plan.
+You are a certified nutritionist. Create a practical, realistic meal plan tailored to the user profile below.
 
 User Profile:
 - Fitness Goal: ${fitnessGoal}
@@ -101,13 +101,20 @@ User Profile:
 - Likes: ${likes || 'N/A'}
 - Dislikes/Restrictions: ${dislikes || 'N/A'}
 
-Create a ${days}-day meal plan with specific meal names for breakfast, lunch, dinner, and 1-2 snacks per day.
-Return ONLY valid JSON with keys "day1" through "day${days}" and for each day include exactly:
+Requirements:
+- Create a ${days}-day plan with 3 meals (breakfast, lunch, dinner) and 1–2 snacks per day.
+- Respect dislikes/restrictions strictly. Prefer items from likes where appropriate.
+- Keep dishes simple, common, and grocery-friendly for easy lookup (no brand names, no emojis).
+- Avoid repetition across consecutive days; include reasonable variety (proteins, grains, vegetables, fruits).
+- Portion assumptions should be implicit; DO NOT include measurements or macros in the names.
+
+Output:
+Return ONLY valid JSON with keys "day1" through "day${days}". For each day include exactly:
 - "breakfast": string
 - "lunch": string
 - "dinner": string
 - "snacks": array of 1-2 strings
-No extra commentary, no markdown. Strict JSON only.
+No extra commentary, no markdown. Strict JSON only with the exact keys above.
 `.trim();
 }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -118,6 +118,19 @@ app.get('/health', (_req, res) => {
   res.json({ ok: true, env: NODE_ENV });
 });
 
+// Friendly root route for browser checks
+app.get('/', (_req, res) => {
+  res.json({
+    ok: true,
+    message: 'PrepAndCount backend is running',
+    endpoints: [
+      'GET /health',
+      'POST /api/generate-meal-plan',
+      'POST /api/generate-meal-plan/enriched'
+    ]
+  });
+});
+
 // --- FatSecret integration (optional) ---
 let fatSecretTokenCache = { token: '', expiresAt: 0 };
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,8 @@ dotenv.config();
 const app = express();
 app.use(cors({ origin: true, credentials: true }));
 app.use(express.json());
+// Ensure CORS preflight responses are handled
+app.options('*', cors({ origin: true, credentials: true }));
 
 const PORT = parseInt(process.env.PORT || '5000', 10);
 const FATSECRET_CLIENT_ID = process.env.FATSECRET_CLIENT_ID || '';
@@ -288,6 +290,25 @@ app.post('/api/generate-meal-plan', async (req, res) => {
 
     const targets = computeTargets({ fitnessGoal, gender, weightKg, heightCm, age, activityLevel });
 
+    // Fast path to isolate OpenAI issues: skip AI and return mock plan
+    const testFlag = String(req.query.test || req.query.skipAi || '').toLowerCase();
+    if (testFlag === '1' || testFlag === 'true') {
+      const mockPlan = {
+        day1: {
+          breakfast: 'Oatmeal with berries',
+          lunch: 'Grilled chicken salad',
+          dinner: 'Salmon with quinoa and veggies',
+          snacks: ['Greek yogurt', 'Apple']
+        }
+      };
+      console.log(`[meal-plan][${reqId}] test-mode ok in ${Date.now() - startedAt}ms`);
+      return res.json({
+        calorieGoal: targets.calorieGoal,
+        macros: targets.macros,
+        plan: mockPlan
+      });
+    }
+
     const openaiKey = process.env.OPENAI_API_KEY;
     if (!openaiKey) {
       return res.status(500).json({ message: 'OPENAI_API_KEY is not configured on the server' });
@@ -342,7 +363,7 @@ app.post('/api/generate-meal-plan', async (req, res) => {
       plan
       // NOTE: FatSecret nutrition enrichment will be added in a follow-up step
     });
-    console.log(`[meal-plan][${reqId}] ok in ${Date.now() - startedAt}ms`);
+    // Note: code after return is unreachable; keep log before return if needed
   } catch (err) {
     console.error('[meal-plan] error', err);
     const message = err?.message || 'Unexpected error';

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,6 +13,7 @@ app.use(express.json());
 const PORT = parseInt(process.env.PORT || '5000', 10);
 const FATSECRET_CLIENT_ID = process.env.FATSECRET_CLIENT_ID || '';
 const FATSECRET_CLIENT_SECRET = process.env.FATSECRET_CLIENT_SECRET || '';
+const NODE_ENV = process.env.NODE_ENV || 'development';
 
 // Helpers
 function toNumber(x, fallback = 0) {
@@ -111,6 +112,11 @@ Create a 7-day meal plan with specific meal names for breakfast, lunch, dinner, 
 No commentary, no markdown. Strict JSON only.
 `.trim();
 }
+
+// Simple health check to verify connectivity from device
+app.get('/health', (_req, res) => {
+  res.json({ ok: true, env: NODE_ENV });
+});
 
 // --- FatSecret integration (optional) ---
 let fatSecretTokenCache = { token: '', expiresAt: 0 };
@@ -238,8 +244,20 @@ async function enrichPlanWithNutrition(plan) {
   return { planWithNutrition: result, totalsByDay };
 }
 
+// Timeout helper to avoid hanging on upstream calls
+function withTimeout(promise, ms, onTimeoutMessage = 'Operation timed out') {
+  let timeoutId;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(onTimeoutMessage)), ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeoutId));
+}
+
 app.post('/api/generate-meal-plan', async (req, res) => {
   try {
+    const startedAt = Date.now();
+    const reqId = Math.random().toString(36).slice(2, 10);
+    console.log(`[meal-plan][${reqId}] start`);
     const {
       fitnessGoal = 'General Health',
       heightCm,
@@ -276,15 +294,19 @@ app.post('/api/generate-meal-plan', async (req, res) => {
       dislikes
     });
 
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-4o-mini',
-      temperature: 0.7,
-      response_format: { type: 'json_object' },
-      messages: [
-        { role: 'system', content: 'You are a helpful assistant that returns strict JSON.' },
-        { role: 'user', content: prompt }
-      ]
-    });
+    const completion = await withTimeout(
+      openai.chat.completions.create({
+        model: 'gpt-4o-mini',
+        temperature: 0.7,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: 'You are a helpful assistant that returns strict JSON.' },
+          { role: 'user', content: prompt }
+        ]
+      }),
+      45000,
+      'OpenAI request timed out'
+    );
 
     const content = completion.choices?.[0]?.message?.content || '{}';
     let plan;
@@ -307,14 +329,20 @@ app.post('/api/generate-meal-plan', async (req, res) => {
       plan
       // NOTE: FatSecret nutrition enrichment will be added in a follow-up step
     });
+    console.log(`[meal-plan][${reqId}] ok in ${Date.now() - startedAt}ms`);
   } catch (err) {
+    console.error('[meal-plan] error', err);
     const message = err?.message || 'Unexpected error';
-    return res.status(500).json({ message });
+    const status = /timed out/i.test(message) ? 504 : 500;
+    return res.status(status).json({ message });
   }
 });
 
 app.post('/api/generate-meal-plan/enriched', async (req, res) => {
   try {
+    const startedAt = Date.now();
+    const reqId = Math.random().toString(36).slice(2, 10);
+    console.log(`[meal-plan-enriched][${reqId}] start`);
     const baseResp = await (async () => {
       // Reuse computation and OpenAI call logic by invoking the main handler body
       const {
@@ -337,15 +365,19 @@ app.post('/api/generate-meal-plan/enriched', async (req, res) => {
         fitnessGoal, heightCm, weightKg, age, gender, activityLevel,
         calorieGoal: targets.calorieGoal, macros: targets.macros, likes, dislikes
       });
-      const completion = await openai.chat.completions.create({
-        model: 'gpt-4o-mini',
-        temperature: 0.7,
-        response_format: { type: 'json_object' },
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant that returns strict JSON.' },
-          { role: 'user', content: prompt }
-        ]
-      });
+      const completion = await withTimeout(
+        openai.chat.completions.create({
+          model: 'gpt-4o-mini',
+          temperature: 0.7,
+          response_format: { type: 'json_object' },
+          messages: [
+            { role: 'system', content: 'You are a helpful assistant that returns strict JSON.' },
+            { role: 'user', content: prompt }
+          ]
+        }),
+        45000,
+        'OpenAI request timed out'
+      );
       const content = completion.choices?.[0]?.message?.content || '{}';
       let plan;
       try {
@@ -364,15 +396,19 @@ app.post('/api/generate-meal-plan/enriched', async (req, res) => {
 
     const { targets, plan } = baseResp.body;
     const { planWithNutrition, totalsByDay } = await enrichPlanWithNutrition(plan);
-    return res.json({
+    const payload = {
       calorieGoal: targets.calorieGoal,
       macros: targets.macros,
       plan: planWithNutrition,
       totalsByDay
-    });
+    };
+    console.log(`[meal-plan-enriched][${reqId}] ok in ${Date.now() - startedAt}ms`);
+    return res.json(payload);
   } catch (err) {
+    console.error('[meal-plan-enriched] error', err);
     const message = err?.message || 'Unexpected error';
-    return res.status(500).json({ message });
+    const status = /timed out/i.test(message) ? 504 : 500;
+    return res.status(status).json({ message });
   }
 });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -85,7 +85,7 @@ function computeTargets({ fitnessGoal, gender, weightKg, heightCm, age, activity
 }
 
 function buildPrompt(p) {
-  const { fitnessGoal, heightCm, weightKg, age, gender, activityLevel, calorieGoal, macros, likes, dislikes } = p;
+  const { fitnessGoal, heightCm, weightKg, age, gender, activityLevel, calorieGoal, macros, likes, dislikes, days = 7 } = p;
   return `
 You are a certified nutritionist. Based on the following user information, create a detailed 7-day meal plan.
 
@@ -101,17 +101,13 @@ User Profile:
 - Likes: ${likes || 'N/A'}
 - Dislikes/Restrictions: ${dislikes || 'N/A'}
 
-Create a 7-day meal plan with specific meal names for breakfast, lunch, dinner, and 1-2 snacks per day. Return ONLY valid JSON with this exact structure and property names:
-{
-  "day1": { "breakfast": "meal name", "lunch": "meal name", "dinner": "meal name", "snacks": ["snack1","snack2"] },
-  "day2": { ... },
-  "day3": { ... },
-  "day4": { ... },
-  "day5": { ... },
-  "day6": { ... },
-  "day7": { ... }
-}
-No commentary, no markdown. Strict JSON only.
+Create a ${days}-day meal plan with specific meal names for breakfast, lunch, dinner, and 1-2 snacks per day.
+Return ONLY valid JSON with keys "day1" through "day${days}" and for each day include exactly:
+- "breakfast": string
+- "lunch": string
+- "dinner": string
+- "snacks": array of 1-2 strings
+No extra commentary, no markdown. Strict JSON only.
 `.trim();
 }
 
@@ -292,6 +288,9 @@ app.post('/api/generate-meal-plan', async (req, res) => {
 
     // Fast path to isolate OpenAI issues: skip AI and return mock plan
     const testFlag = String(req.query.test || req.query.skipAi || '').toLowerCase();
+    const daysParam = Math.max(1, Math.min(7, Number(req.query.days) || 7));
+    const timeoutMs = Math.max(10000, Math.min(90000, Number(req.query.timeoutMs) || 45000));
+    const modelParam = String(req.query.model || 'gpt-4o-mini');
     if (testFlag === '1' || testFlag === 'true') {
       const mockPlan = {
         day1: {
@@ -305,7 +304,15 @@ app.post('/api/generate-meal-plan', async (req, res) => {
       return res.json({
         calorieGoal: targets.calorieGoal,
         macros: targets.macros,
-        plan: mockPlan
+        plan: daysParam === 1 ? mockPlan : {
+          ...mockPlan,
+          day2: mockPlan.day1,
+          day3: mockPlan.day1,
+          day4: mockPlan.day1,
+          day5: mockPlan.day1,
+          day6: mockPlan.day1,
+          day7: mockPlan.day1
+        }
       });
     }
 
@@ -325,12 +332,13 @@ app.post('/api/generate-meal-plan', async (req, res) => {
       calorieGoal: targets.calorieGoal,
       macros: targets.macros,
       likes,
-      dislikes
+      dislikes,
+      days: daysParam
     });
 
     const completion = await withTimeout(
       openai.chat.completions.create({
-        model: 'gpt-4o-mini',
+        model: modelParam,
         temperature: 0.7,
         response_format: { type: 'json_object' },
         messages: [
@@ -338,7 +346,7 @@ app.post('/api/generate-meal-plan', async (req, res) => {
           { role: 'user', content: prompt }
         ]
       }),
-      45000,
+      timeoutMs,
       'OpenAI request timed out'
     );
 
@@ -354,6 +362,18 @@ app.post('/api/generate-meal-plan', async (req, res) => {
         plan = JSON.parse(content.slice(start, end + 1));
       } else {
         throw new Error('Failed to parse OpenAI JSON response');
+      }
+    }
+
+    // If the model returned all 7 days but a smaller number was requested, trim it
+    if (daysParam < 7) {
+      const trimmed = {};
+      for (let i = 1; i <= daysParam; i++) {
+        const key = `day${i}`;
+        if (plan[key]) trimmed[key] = plan[key];
+      }
+      if (Object.keys(trimmed).length > 0) {
+        plan = trimmed;
       }
     }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import { OpenAI } from 'openai';
+import crypto from 'crypto';
 
 dotenv.config();
 
@@ -10,6 +11,8 @@ app.use(cors({ origin: true, credentials: true }));
 app.use(express.json());
 
 const PORT = parseInt(process.env.PORT || '5000', 10);
+const FATSECRET_CLIENT_ID = process.env.FATSECRET_CLIENT_ID || '';
+const FATSECRET_CLIENT_SECRET = process.env.FATSECRET_CLIENT_SECRET || '';
 
 // Helpers
 function toNumber(x, fallback = 0) {
@@ -109,6 +112,132 @@ No commentary, no markdown. Strict JSON only.
 `.trim();
 }
 
+// --- FatSecret integration (optional) ---
+let fatSecretTokenCache = { token: '', expiresAt: 0 };
+
+async function getFatSecretToken() {
+  if (!FATSECRET_CLIENT_ID || !FATSECRET_CLIENT_SECRET) return null;
+  const now = Date.now();
+  if (fatSecretTokenCache.token && fatSecretTokenCache.expiresAt > now + 60_000) {
+    return fatSecretTokenCache.token;
+  }
+  const credentials = Buffer.from(`${FATSECRET_CLIENT_ID}:${FATSECRET_CLIENT_SECRET}`).toString('base64');
+  const resp = await fetch('https://oauth.fatsecret.com/connect/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Authorization': `Basic ${credentials}`
+    },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      scope: 'premier'
+    }).toString()
+  });
+  if (!resp.ok) return null;
+  const data = await resp.json();
+  fatSecretTokenCache = {
+    token: data.access_token || '',
+    expiresAt: now + ((data.expires_in || 3600) * 1000)
+  };
+  return fatSecretTokenCache.token;
+}
+
+async function fatSecretSearchFood(name, token) {
+  const params = new URLSearchParams({
+    search_expression: name,
+    max_results: '1',
+    region: 'US',
+    language: 'en',
+    format: 'json'
+  });
+  const url = `https://platform.fatsecret.com/rest/foods/search/v3?${params.toString()}`;
+  const resp = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    }
+  });
+  if (!resp.ok) return null;
+  const data = await resp.json();
+  try {
+    const first = data.foods_search?.results?.foods?.[0];
+    return first || null;
+  } catch {
+    return null;
+  }
+}
+
+function extractMacrosFromFood(food) {
+  // Different endpoints return different shapes; try to normalize
+  const serving = food?.servings?.serving?.[0] || food?.servings?.serving || {};
+  const calories = toNumber(serving.calories);
+  const protein = toNumber(serving.protein);
+  const carbs = toNumber(serving.carbohydrate);
+  const fat = toNumber(serving.fat);
+  if (calories || protein || carbs || fat) {
+    return { calories, protein, carbs, fat };
+  }
+  return null;
+}
+
+async function enrichPlanWithNutrition(plan) {
+  const token = await getFatSecretToken();
+  if (!token) return { planWithNutrition: plan, totalsByDay: {} };
+
+  const result = {};
+  const totalsByDay = {};
+  const dayKeys = Object.keys(plan || {});
+
+  for (const day of dayKeys) {
+    const meals = plan[day] || {};
+    const keys = ['breakfast', 'lunch', 'dinner'];
+    const snacks = Array.isArray(meals.snacks) ? meals.snacks.slice(0, 2) : [];
+
+    result[day] = { breakfast: null, lunch: null, dinner: null, snacks: [] };
+    const dayTotals = { calories: 0, protein: 0, carbs: 0, fat: 0 };
+
+    // Helper to process one item
+    const processItem = async (label, name) => {
+      if (!name) return null;
+      const food = await fatSecretSearchFood(name, token);
+      const macros = extractMacrosFromFood(food);
+      if (macros) {
+        dayTotals.calories += macros.calories;
+        dayTotals.protein += macros.protein;
+        dayTotals.carbs += macros.carbs;
+        dayTotals.fat += macros.fat;
+      }
+      return { name, macros };
+    };
+
+    for (const k of keys) {
+      try {
+        result[day][k] = await processItem(k, meals[k]);
+      } catch {
+        result[day][k] = { name: meals[k] || null, macros: null };
+      }
+    }
+    const snackResults = [];
+    for (const s of snacks) {
+      try {
+        snackResults.push(await processItem('snack', s));
+      } catch {
+        snackResults.push({ name: s, macros: null });
+      }
+    }
+    result[day].snacks = snackResults;
+    totalsByDay[day] = {
+      calories: Math.round(dayTotals.calories),
+      protein: Math.round(dayTotals.protein),
+      carbs: Math.round(dayTotals.carbs),
+      fat: Math.round(dayTotals.fat)
+    };
+  }
+
+  return { planWithNutrition: result, totalsByDay };
+}
+
 app.post('/api/generate-meal-plan', async (req, res) => {
   try {
     const {
@@ -177,6 +306,69 @@ app.post('/api/generate-meal-plan', async (req, res) => {
       macros: targets.macros,
       plan
       // NOTE: FatSecret nutrition enrichment will be added in a follow-up step
+    });
+  } catch (err) {
+    const message = err?.message || 'Unexpected error';
+    return res.status(500).json({ message });
+  }
+});
+
+app.post('/api/generate-meal-plan/enriched', async (req, res) => {
+  try {
+    const baseResp = await (async () => {
+      // Reuse computation and OpenAI call logic by invoking the main handler body
+      const {
+        fitnessGoal = 'General Health',
+        heightCm,
+        weightKg,
+        age,
+        gender = 'Other',
+        activityLevel = 'Sedentary',
+        likes = '',
+        dislikes = ''
+      } = req.body || {};
+
+      if (!heightCm || !weightKg || !age) {
+        return { status: 400, body: { message: 'heightCm, weightKg, and age are required' } };
+      }
+      const targets = computeTargets({ fitnessGoal, gender, weightKg, heightCm, age, activityLevel });
+      const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+      const prompt = buildPrompt({
+        fitnessGoal, heightCm, weightKg, age, gender, activityLevel,
+        calorieGoal: targets.calorieGoal, macros: targets.macros, likes, dislikes
+      });
+      const completion = await openai.chat.completions.create({
+        model: 'gpt-4o-mini',
+        temperature: 0.7,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: 'You are a helpful assistant that returns strict JSON.' },
+          { role: 'user', content: prompt }
+        ]
+      });
+      const content = completion.choices?.[0]?.message?.content || '{}';
+      let plan;
+      try {
+        plan = JSON.parse(content);
+      } catch {
+        const start = content.indexOf('{');
+        const end = content.lastIndexOf('}');
+        plan = JSON.parse(content.slice(start, end + 1));
+      }
+      return { status: 200, body: { targets, plan } };
+    })();
+
+    if (baseResp.status !== 200) {
+      return res.status(baseResp.status).json(baseResp.body);
+    }
+
+    const { targets, plan } = baseResp.body;
+    const { planWithNutrition, totalsByDay } = await enrichPlanWithNutrition(plan);
+    return res.json({
+      calorieGoal: targets.calorieGoal,
+      macros: targets.macros,
+      plan: planWithNutrition,
+      totalsByDay
     });
   } catch (err) {
     const message = err?.message || 'Unexpected error';

--- a/backend/server.js
+++ b/backend/server.js
@@ -399,6 +399,51 @@ app.post('/api/generate-meal-plan', async (req, res) => {
   }
 });
 
+app.post('/api/recipe-instructions', async (req, res) => {
+  try {
+    const { mealName } = req.body || {};
+    if (!mealName) return res.status(400).json({ message: 'mealName is required' });
+    const openaiKey = process.env.OPENAI_API_KEY;
+    if (!openaiKey) return res.status(500).json({ message: 'OPENAI_API_KEY is not configured on the server' });
+    const openai = new OpenAI({ apiKey: openaiKey });
+    const prompt = `
+You are a chef. Provide concise home-cook instructions for the dish: "${mealName}".
+Constraints:
+- 4–6 short numbered steps
+- Common ingredients and simple techniques only
+- No quantities, calories, or macros
+- No extra commentary or markdown
+Return STRICT JSON: { "steps": ["step 1", "step 2", ...] }`.trim();
+    const completion = await withTimeout(
+      openai.chat.completions.create({
+        model: 'gpt-4o-mini',
+        temperature: 0.4,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: 'You return strict JSON only.' },
+          { role: 'user', content: prompt }
+        ]
+      }),
+      25000,
+      'OpenAI request timed out'
+    );
+    const content = completion.choices?.[0]?.message?.content || '{}';
+    let data;
+    try {
+      data = JSON.parse(content);
+    } catch {
+      const start = content.indexOf('{');
+      const end = content.lastIndexOf('}');
+      data = JSON.parse(content.slice(start, end + 1));
+    }
+    return res.json({ steps: Array.isArray(data.steps) ? data.steps.slice(0, 8) : [] });
+  } catch (err) {
+    const message = err?.message || 'Unexpected error';
+    const status = /timed out/i.test(message) ? 504 : 500;
+    return res.status(status).json({ message });
+  }
+});
+
 app.post('/api/generate-meal-plan/enriched', async (req, res) => {
   try {
     const startedAt = Date.now();

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,191 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import { OpenAI } from 'openai';
+
+dotenv.config();
+
+const app = express();
+app.use(cors({ origin: true, credentials: true }));
+app.use(express.json());
+
+const PORT = parseInt(process.env.PORT || '5000', 10);
+
+// Helpers
+function toNumber(x, fallback = 0) {
+  const n = Number(x);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function mifflinStJeorBmr({ gender, weightKg, heightCm, age }) {
+  const w = toNumber(weightKg);
+  const h = toNumber(heightCm);
+  const a = toNumber(age);
+  // Mifflin-St Jeor
+  const base = 10 * w + 6.25 * h - 5 * a;
+  return gender === 'Male' ? base + 5 : base - 161;
+}
+
+function activityMultiplier(level) {
+  switch (level) {
+    case 'Sedentary': return 1.2;
+    case 'Lightly Active': return 1.375;
+    case 'Moderately Active': return 1.55;
+    case 'Very Active': return 1.725;
+    case 'Extra Active': return 1.9;
+    default: return 1.2;
+  }
+}
+
+function calorieAdjustmentForGoal(goal) {
+  switch (goal) {
+    case 'Weight Loss': return -500; // ~1 lb/week
+    case 'Muscle Gain': return 300;
+    case 'Maintenance': return 0;
+    case 'General Health': return 0;
+    default: return 0;
+  }
+}
+
+function computeTargets({ fitnessGoal, gender, weightKg, heightCm, age, activityLevel }) {
+  const bmr = mifflinStJeorBmr({ gender, weightKg, heightCm, age });
+  const tdee = bmr * activityMultiplier(activityLevel);
+  const calorieGoal = Math.max(1200, tdee + calorieAdjustmentForGoal(fitnessGoal));
+
+  // Protein target by goal (g/kg)
+  const proteinPerKg =
+    fitnessGoal === 'Muscle Gain' ? 1.8 :
+    fitnessGoal === 'Weight Loss' ? 1.8 :
+    fitnessGoal === 'Maintenance' ? 1.6 : 1.4;
+  const proteinGrams = Math.max(50, toNumber(weightKg) * proteinPerKg);
+
+  // Fat ~25% calories
+  const fatCalories = calorieGoal * 0.25;
+  const fatGrams = fatCalories / 9;
+
+  // Carbs = remaining
+  const proteinCalories = proteinGrams * 4;
+  const carbsCalories = Math.max(0, calorieGoal - (proteinCalories + fatCalories));
+  const carbGrams = carbsCalories / 4;
+
+  return {
+    calorieGoal,
+    macros: {
+      proteinGrams,
+      carbGrams,
+      fatGrams
+    }
+  };
+}
+
+function buildPrompt(p) {
+  const { fitnessGoal, heightCm, weightKg, age, gender, activityLevel, calorieGoal, macros, likes, dislikes } = p;
+  return `
+You are a certified nutritionist. Based on the following user information, create a detailed 7-day meal plan.
+
+User Profile:
+- Fitness Goal: ${fitnessGoal}
+- Height: ${heightCm} cm
+- Weight: ${weightKg} kg
+- Age: ${age}
+- Gender: ${gender}
+- Activity Level: ${activityLevel}
+- Daily Calorie Target: ${Math.round(calorieGoal)}
+- Macro Targets: Protein: ${Math.round(macros.proteinGrams)}g, Carbs: ${Math.round(macros.carbGrams)}g, Fat: ${Math.round(macros.fatGrams)}g
+- Likes: ${likes || 'N/A'}
+- Dislikes/Restrictions: ${dislikes || 'N/A'}
+
+Create a 7-day meal plan with specific meal names for breakfast, lunch, dinner, and 1-2 snacks per day. Return ONLY valid JSON with this exact structure and property names:
+{
+  "day1": { "breakfast": "meal name", "lunch": "meal name", "dinner": "meal name", "snacks": ["snack1","snack2"] },
+  "day2": { ... },
+  "day3": { ... },
+  "day4": { ... },
+  "day5": { ... },
+  "day6": { ... },
+  "day7": { ... }
+}
+No commentary, no markdown. Strict JSON only.
+`.trim();
+}
+
+app.post('/api/generate-meal-plan', async (req, res) => {
+  try {
+    const {
+      fitnessGoal = 'General Health',
+      heightCm,
+      weightKg,
+      age,
+      gender = 'Other',
+      activityLevel = 'Sedentary',
+      likes = '',
+      dislikes = ''
+    } = req.body || {};
+
+    if (!heightCm || !weightKg || !age) {
+      return res.status(400).json({ message: 'heightCm, weightKg, and age are required' });
+    }
+
+    const targets = computeTargets({ fitnessGoal, gender, weightKg, heightCm, age, activityLevel });
+
+    const openaiKey = process.env.OPENAI_API_KEY;
+    if (!openaiKey) {
+      return res.status(500).json({ message: 'OPENAI_API_KEY is not configured on the server' });
+    }
+    const openai = new OpenAI({ apiKey: openaiKey });
+
+    const prompt = buildPrompt({
+      fitnessGoal,
+      heightCm,
+      weightKg,
+      age,
+      gender,
+      activityLevel,
+      calorieGoal: targets.calorieGoal,
+      macros: targets.macros,
+      likes,
+      dislikes
+    });
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      temperature: 0.7,
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant that returns strict JSON.' },
+        { role: 'user', content: prompt }
+      ]
+    });
+
+    const content = completion.choices?.[0]?.message?.content || '{}';
+    let plan;
+    try {
+      plan = JSON.parse(content);
+    } catch (e) {
+      // Attempt to salvage JSON
+      const start = content.indexOf('{');
+      const end = content.lastIndexOf('}');
+      if (start !== -1 && end !== -1) {
+        plan = JSON.parse(content.slice(start, end + 1));
+      } else {
+        throw new Error('Failed to parse OpenAI JSON response');
+      }
+    }
+
+    return res.json({
+      calorieGoal: targets.calorieGoal,
+      macros: targets.macros,
+      plan
+      // NOTE: FatSecret nutrition enrichment will be added in a follow-up step
+    });
+  } catch (err) {
+    const message = err?.message || 'Unexpected error';
+    return res.status(500).json({ message });
+  }
+});
+
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -444,6 +444,49 @@ Return STRICT JSON: { "steps": ["step 1", "step 2", ...] }`.trim();
   }
 });
 
+app.post('/api/nutrition/estimate', async (req, res) => {
+  try {
+    const items = Array.isArray(req.body?.items) ? req.body.items : [];
+    if (items.length === 0) {
+      return res.json({ byKey: {}, totals: { calories: 0, protein: 0, carbs: 0, fat: 0 } });
+    }
+    const token = await getFatSecretToken();
+    const byKey = {};
+    const totals = { calories: 0, protein: 0, carbs: 0, fat: 0 };
+    if (!token) {
+      // FatSecret not configured; return null macros for each item
+      for (const it of items) {
+        byKey[it.key] = null;
+      }
+      return res.json({ byKey, totals });
+    }
+    for (const it of items) {
+      try {
+        const food = await fatSecretSearchFood(String(it.name || ''), token);
+        const macros = extractMacrosFromFood(food);
+        byKey[it.key] = macros || null;
+        if (macros) {
+          totals.calories += macros.calories || 0;
+          totals.protein += macros.protein || 0;
+          totals.carbs += macros.carbs || 0;
+          totals.fat += macros.fat || 0;
+        }
+      } catch {
+        byKey[it.key] = null;
+      }
+    }
+    totals.calories = Math.round(totals.calories);
+    totals.protein = Math.round(totals.protein);
+    totals.carbs = Math.round(totals.carbs);
+    totals.fat = Math.round(totals.fat);
+    return res.json({ byKey, totals });
+  } catch (err) {
+    const message = err?.message || 'Unexpected error';
+    const status = /timed out/i.test(message) ? 504 : 500;
+    return res.status(status).json({ message });
+  }
+});
+
 app.post('/api/generate-meal-plan/enriched', async (req, res) => {
   try {
     const startedAt = Date.now();

--- a/frontend/app/_layout.jsx
+++ b/frontend/app/_layout.jsx
@@ -21,6 +21,7 @@ import { MealTimesContext } from '../hooks/mealTimes';
 import { MacroProvider } from '../hooks/macroContext';
 import { Settings } from 'react-native';
 import FitnessSettingsScreen from '../src/screens/FitnessSettingsScreen';
+import MealPlannerScreen from '../src/screens/MealPlannerScreen';
 
 
 
@@ -126,6 +127,8 @@ export default function RootLayout() {
                   iconName = focused ? 'cart' : 'cart-outline';
                 } else if (route.name === 'Add Food') {
                   iconName = focused ? 'add-circle' : 'add-circle-outline';
+                } else if (route.name === 'Meal Planner') {
+                  iconName = focused ? 'restaurant' : 'restaurant-outline';
                 } else if (route.name === 'Settings') {
                   iconName = focused ? 'settings' : 'settings-outline';
                 }
@@ -145,6 +148,7 @@ export default function RootLayout() {
             <Tab.Screen name="Home" component={HomeScreen} />
             <Tab.Screen name="Grocery List" component={GroceryListScreen} />
             <Tab.Screen name="Add Food" component={AddFoodStackScreen} />
+            <Tab.Screen name="Meal Planner" component={MealPlannerScreen} />
             <Tab.Screen name="Settings" component={SettingsStackScreen} />
           </Tab.Navigator>
           <StatusBar style="auto" />

--- a/frontend/app/_layout.jsx
+++ b/frontend/app/_layout.jsx
@@ -31,6 +31,7 @@ SplashScreen.preventAutoHideAsync();
 const Tab = createBottomTabNavigator();
 const SettingsStack = createNativeStackNavigator();
 const AddFoodStack = createNativeStackNavigator();
+const MealPlannerStack = createNativeStackNavigator();
 
 
 export const DMContext = React.createContext({});
@@ -110,6 +111,24 @@ export default function RootLayout() {
     </AddFoodStack.Navigator>
   );
   
+  const MealPlannerStackScreen = () => (
+    <MealPlannerStack.Navigator>
+      <MealPlannerStack.Screen 
+        options={{ headerShown: false }}
+        name="Meal Planner Home"
+        component={MealPlannerScreen}
+      />
+      <MealPlannerStack.Screen 
+        options={{
+          headerStyle: { backgroundColor: darkModeEnabled ? "#1c1b1a" : "#fff" }, 
+          headerTintColor: darkModeEnabled ? "#fff" : "#333"
+        }}
+        name="Meal Plan Day"
+        component={require('../src/screens/MealPlanDayScreen').default}
+      />
+    </MealPlannerStack.Navigator>
+  );
+
 
 
   return (
@@ -148,7 +167,7 @@ export default function RootLayout() {
             <Tab.Screen name="Home" component={HomeScreen} />
             <Tab.Screen name="Grocery List" component={GroceryListScreen} />
             <Tab.Screen name="Add Food" component={AddFoodStackScreen} />
-            <Tab.Screen name="Meal Planner" component={MealPlannerScreen} />
+            <Tab.Screen name="Meal Planner" component={MealPlannerStackScreen} />
             <Tab.Screen name="Settings" component={SettingsStackScreen} />
           </Tab.Navigator>
           <StatusBar style="auto" />

--- a/frontend/config/config.js
+++ b/frontend/config/config.js
@@ -1,0 +1,7 @@
+const API_URL = process.env.EXPO_PUBLIC_API_URL;
+
+if (!API_URL) {
+	console.warn('EXPO_PUBLIC_API_URL is not set. Create frontend/.env and restart Expo.');
+}
+
+export default API_URL;

--- a/frontend/src/screens/MealPlanDayScreen.jsx
+++ b/frontend/src/screens/MealPlanDayScreen.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator } from 'react-native';
-import { callSearch, callFindByID } from '../../api/callAPI';
 import API_URL from '../../config/config';
 
 export default function MealPlanDayScreen({ route }) {
@@ -25,34 +24,15 @@ export default function MealPlanDayScreen({ route }) {
     const fetchMacros = async () => {
       try {
         setLoading(true);
-        const out = {};
-        for (const it of items) {
-          try {
-            const search = await callSearch(it.name, 0);
-            const first = Array.isArray(search?.[0]?.foods) ? search[0].foods[0] : null;
-            const foodId = first?.food_id || first?.food_id?.toString?.();
-            if (!foodId) {
-              out[it.key] = null;
-              continue;
-            }
-            const details = await callFindByID(String(foodId));
-            const servings = details?.[2];
-            const serving = Array.isArray(servings?.serving) ? servings.serving[0] : servings?.serving || null;
-            if (serving) {
-              out[it.key] = {
-                calories: Number(serving.calories) || 0,
-                protein: Number(serving.protein) || 0,
-                carbs: Number(serving.carbohydrate) || 0,
-                fat: Number(serving.fat) || 0
-              };
-            } else {
-              out[it.key] = null;
-            }
-          } catch {
-            out[it.key] = null;
-          }
-        }
-        if (!cancelled) setMacrosByItem(out);
+        const payload = { items: items.map(it => ({ key: it.key, name: it.name })) };
+        const resp = await fetch(`${API_URL}/api/nutrition/estimate`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (!cancelled) setMacrosByItem(data.byKey || {});
       } catch (e) {
         if (!cancelled) setError(e?.message || 'Failed to fetch macros');
       } finally {

--- a/frontend/src/screens/MealPlanDayScreen.jsx
+++ b/frontend/src/screens/MealPlanDayScreen.jsx
@@ -1,0 +1,146 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { callSearch, callFindByID } from '../../api/callAPI';
+import API_URL from '../../config/config';
+
+export default function MealPlanDayScreen({ route }) {
+  const { dayKey = 'day1', meals = {}, calorieGoal, macros } = route.params || {};
+  const [macrosByItem, setMacrosByItem] = useState({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [instructions, setInstructions] = useState({});
+  const mealOrder = ['breakfast', 'lunch', 'dinner'];
+  const snacks = Array.isArray(meals?.snacks) ? meals.snacks : [];
+
+  const items = useMemo(() => {
+    const base = mealOrder
+      .map(k => ({ key: k, name: meals?.[k] }))
+      .filter(x => !!x.name);
+    const snackItems = snacks.map((s, idx) => ({ key: `snack${idx + 1}`, name: s }));
+    return [...base, ...snackItems];
+  }, [meals, snacks]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchMacros = async () => {
+      try {
+        setLoading(true);
+        const out = {};
+        for (const it of items) {
+          try {
+            const search = await callSearch(it.name, 0);
+            const first = Array.isArray(search?.[0]?.foods) ? search[0].foods[0] : null;
+            const foodId = first?.food_id || first?.food_id?.toString?.();
+            if (!foodId) {
+              out[it.key] = null;
+              continue;
+            }
+            const details = await callFindByID(String(foodId));
+            const servings = details?.[2];
+            const serving = Array.isArray(servings?.serving) ? servings.serving[0] : servings?.serving || null;
+            if (serving) {
+              out[it.key] = {
+                calories: Number(serving.calories) || 0,
+                protein: Number(serving.protein) || 0,
+                carbs: Number(serving.carbohydrate) || 0,
+                fat: Number(serving.fat) || 0
+              };
+            } else {
+              out[it.key] = null;
+            }
+          } catch {
+            out[it.key] = null;
+          }
+        }
+        if (!cancelled) setMacrosByItem(out);
+      } catch (e) {
+        if (!cancelled) setError(e?.message || 'Failed to fetch macros');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    if (items.length > 0) fetchMacros();
+    return () => { cancelled = true; };
+  }, [items]);
+
+  const loadInstructions = async (name, key) => {
+    try {
+      setInstructions(prev => ({ ...prev, [key]: { loading: true } }));
+      const res = await fetch(`${API_URL}/api/recipe-instructions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mealName: name })
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setInstructions(prev => ({ ...prev, [key]: { steps: data.steps || [] } }));
+    } catch (e) {
+      setInstructions(prev => ({ ...prev, [key]: { error: e?.message || 'Failed to load instructions' } }));
+    }
+  };
+
+  const renderRow = (label, key, name) => {
+    const m = macrosByItem[key];
+    const info = instructions[key];
+    return (
+      <View key={key} style={styles.card}>
+        <Text style={styles.mealTitle}>{label}</Text>
+        <Text style={styles.mealName}>{name}</Text>
+        <Text style={styles.small}>
+          {m ? `≈ ${Math.round(m.calories)} kcal | P ${Math.round(m.protein)}g · C ${Math.round(m.carbs)}g · F ${Math.round(m.fat)}g` : 'Macros unavailable'}
+        </Text>
+        <TouchableOpacity style={styles.btn} onPress={() => loadInstructions(name, key)}>
+          <Text style={styles.btnText}>How to cook</Text>
+        </TouchableOpacity>
+        {info?.loading && <ActivityIndicator style={{ marginTop: 6 }} />}
+        {!!info?.error && <Text style={[styles.small, { color: '#c00' }]}>{info.error}</Text>}
+        {Array.isArray(info?.steps) && info.steps.length > 0 && (
+          <View style={styles.steps}>
+            {info.steps.map((s, i) => (
+              <Text key={i} style={styles.stepLine}>{`${i + 1}. ${s}`}</Text>
+            ))}
+          </View>
+        )}
+      </View>
+    );
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>{String(dayKey).toUpperCase()}</Text>
+      {!!calorieGoal && !!macros && (
+        <View style={styles.summary}>
+          <Text style={styles.summaryText}>Daily Target: {Math.round(calorieGoal)} kcal</Text>
+          <Text style={styles.summaryText}>P {Math.round(macros.proteinGrams)}g · C {Math.round(macros.carbGrams)}g · F {Math.round(macros.fatGrams)}g</Text>
+        </View>
+      )}
+      {!!error && <Text style={[styles.small, { color: '#c00' }]}>{error}</Text>}
+      {loading && <ActivityIndicator />}
+      {mealOrder.map(k => meals?.[k] ? renderRow(k[0].toUpperCase() + k.slice(1), k, meals[k]) : null)}
+      {snacks.length > 0 && (
+        <View style={{ marginTop: 10 }}>
+          <Text style={styles.section}>Snacks</Text>
+          {snacks.map((s, idx) => renderRow(`Snack ${idx + 1}`, `snack${idx + 1}`, s))}
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16 },
+  title: { fontSize: 22, fontWeight: '700' },
+  summary: { marginTop: 8 },
+  summaryText: { color: '#555' },
+  card: { marginTop: 12, padding: 12, borderWidth: 1, borderColor: '#eee', borderRadius: 10 },
+  mealTitle: { fontWeight: '700', marginBottom: 4 },
+  mealName: { marginBottom: 4 },
+  small: { fontSize: 12, color: '#666' },
+  btn: { marginTop: 8, backgroundColor: '#007aff', paddingVertical: 10, borderRadius: 8, alignItems: 'center' },
+  btnText: { color: '#fff', fontWeight: '700' },
+  section: { fontWeight: '700', marginBottom: 6 },
+  steps: { marginTop: 8 },
+  stepLine: { marginTop: 4 }
+});
+
+

--- a/frontend/src/screens/MealPlannerScreen.jsx
+++ b/frontend/src/screens/MealPlannerScreen.jsx
@@ -29,6 +29,7 @@ export default function MealPlannerScreen() {
   const [result, setResult] = useState(null);
   const [testMode, setTestMode] = useState(false);
   const [pingStatus, setPingStatus] = useState('');
+  const [oneDay, setOneDay] = useState(false);
 
   const canSubmit = useMemo(() => {
     return (
@@ -45,7 +46,10 @@ export default function MealPlannerScreen() {
     setError('');
     setResult(null);
     try {
-      const qs = testMode ? '?test=1' : '';
+      const params = new URLSearchParams();
+      if (testMode) params.set('test', '1');
+      params.set('days', oneDay ? '1' : '7');
+      const qs = params.toString() ? `?${params.toString()}` : '';
       const res = await fetch(`${API_URL}/api/generate-meal-plan${qs}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -83,6 +87,10 @@ export default function MealPlannerScreen() {
       <View style={styles.testRow}>
         <Text style={styles.label}>Test mode (skip AI)</Text>
         <Switch value={testMode} onValueChange={setTestMode} />
+      </View>
+      <View style={styles.testRow}>
+        <Text style={styles.label}>Quick (1 day)</Text>
+        <Switch value={oneDay} onValueChange={setOneDay} />
       </View>
       <View style={[styles.testRow, { marginTop: 6 }]}>
         <TouchableOpacity style={[styles.button, { paddingVertical: 10 }]} onPress={checkConnection}>

--- a/frontend/src/screens/MealPlannerScreen.jsx
+++ b/frontend/src/screens/MealPlannerScreen.jsx
@@ -1,0 +1,285 @@
+import React, { useMemo, useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator, ScrollView } from 'react-native';
+
+const goals = ['Weight Loss', 'Muscle Gain', 'Maintenance', 'General Health'];
+const genders = ['Male', 'Female', 'Other'];
+const activityLevels = [
+  'Sedentary',
+  'Lightly Active',
+  'Moderately Active',
+  'Very Active',
+  'Extra Active'
+];
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://10.200.237.49:5000';
+
+export default function MealPlannerScreen() {
+  const [form, setForm] = useState({
+    fitnessGoal: 'General Health',
+    heightCm: '',
+    weightKg: '',
+    age: '',
+    gender: 'Other',
+    activityLevel: 'Sedentary',
+    likes: '',
+    dislikes: ''
+  });
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState(null);
+
+  const canSubmit = useMemo(() => {
+    return (
+      !!form.heightCm && !!form.weightKg && !!form.age &&
+      Number(form.heightCm) > 0 && Number(form.weightKg) > 0 && Number(form.age) > 0
+    );
+  }, [form]);
+
+  const updateField = (key, value) => setForm(prev => ({ ...prev, [key]: value }));
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setLoading(true);
+    setError('');
+    setResult(null);
+    try {
+      const res = await fetch(`${API_URL}/api/generate-meal-plan`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form)
+      });
+      if (!res.ok) {
+        const msg = await res.text();
+        throw new Error(msg || `Request failed (${res.status})`);
+      }
+      const data = await res.json();
+      setResult(data);
+    } catch (e) {
+      setError(e?.message || 'Failed to generate meal plan');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>Meal Planner</Text>
+
+      <Text style={styles.label}>Fitness Goal</Text>
+      <View style={styles.rowWrap}>
+        {goals.map(g => (
+          <TouchableOpacity
+            key={g}
+            style={[styles.chip, form.fitnessGoal === g && styles.chipActive]}
+            onPress={() => updateField('fitnessGoal', g)}
+          >
+            <Text style={[styles.chipText, form.fitnessGoal === g && styles.chipTextActive]}>
+              {g}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <Text style={styles.label}>Gender</Text>
+      <View style={styles.rowWrap}>
+        {genders.map(g => (
+          <TouchableOpacity
+            key={g}
+            style={[styles.chip, form.gender === g && styles.chipActive]}
+            onPress={() => updateField('gender', g)}
+          >
+            <Text style={[styles.chipText, form.gender === g && styles.chipTextActive]}>{g}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <Text style={styles.label}>Activity Level</Text>
+      <View style={styles.rowWrap}>
+        {activityLevels.map(a => (
+          <TouchableOpacity
+            key={a}
+            style={[styles.chip, form.activityLevel === a && styles.chipActive]}
+            onPress={() => updateField('activityLevel', a)}
+          >
+            <Text style={[styles.chipText, form.activityLevel === a && styles.chipTextActive]}>
+              {a}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <Text style={styles.label}>Height (cm)</Text>
+      <TextInput
+        keyboardType="numeric"
+        value={String(form.heightCm)}
+        onChangeText={(t) => updateField('heightCm', t.replace(/[^0-9.]/g, ''))}
+        style={styles.input}
+        placeholder="e.g., 175"
+      />
+
+      <Text style={styles.label}>Weight (kg)</Text>
+      <TextInput
+        keyboardType="numeric"
+        value={String(form.weightKg)}
+        onChangeText={(t) => updateField('weightKg', t.replace(/[^0-9.]/g, ''))}
+        style={styles.input}
+        placeholder="e.g., 70"
+      />
+
+      <Text style={styles.label}>Age</Text>
+      <TextInput
+        keyboardType="numeric"
+        value={String(form.age)}
+        onChangeText={(t) => updateField('age', t.replace(/[^0-9]/g, ''))}
+        style={styles.input}
+        placeholder="e.g., 28"
+      />
+
+      <Text style={styles.label}>Likes</Text>
+      <TextInput
+        value={form.likes}
+        onChangeText={(t) => updateField('likes', t)}
+        style={[styles.input, styles.multiline]}
+        placeholder="Foods you like"
+        multiline
+      />
+
+      <Text style={styles.label}>Dislikes / Restrictions</Text>
+      <TextInput
+        value={form.dislikes}
+        onChangeText={(t) => updateField('dislikes', t)}
+        style={[styles.input, styles.multiline]}
+        placeholder="Dislikes, allergies"
+        multiline
+      />
+
+      <TouchableOpacity style={[styles.button, !canSubmit && styles.buttonDisabled]} disabled={!canSubmit || loading} onPress={submit}>
+        {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.buttonText}>Generate Meal Plan</Text>}
+      </TouchableOpacity>
+
+      {!!error && <Text style={styles.error}>{error}</Text>}
+
+      {result && (
+        <View style={styles.resultContainer}>
+          <Text style={styles.sectionTitle}>Daily Target</Text>
+          <Text style={styles.resultText}>Calories: {Math.round(result.calorieGoal)} kcal</Text>
+          <Text style={styles.resultText}>Protein: {Math.round(result.macros.proteinGrams)} g</Text>
+          <Text style={styles.resultText}>Carbs: {Math.round(result.macros.carbGrams)} g</Text>
+          <Text style={styles.resultText}>Fat: {Math.round(result.macros.fatGrams)} g</Text>
+
+          <Text style={[styles.sectionTitle, { marginTop: 16 }]}>7-Day Plan</Text>
+          {Object.entries(result.plan || {}).map(([day, meals]) => (
+            <View key={day} style={styles.dayBlock}>
+              <Text style={styles.dayTitle}>{String(day).toUpperCase()}</Text>
+              {['breakfast', 'lunch', 'dinner'].map(mealKey => (
+                meals?.[mealKey] ? (
+                  <Text key={mealKey} style={styles.mealText}>
+                    {mealKey[0].toUpperCase() + mealKey.slice(1)}: {meals[mealKey]}
+                  </Text>
+                ) : null
+              ))}
+              {Array.isArray(meals?.snacks) && meals.snacks.length > 0 && (
+                <Text style={styles.mealText}>Snacks: {meals.snacks.join(', ')}</Text>
+              )}
+            </View>
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 12
+  },
+  label: {
+    marginTop: 12,
+    fontWeight: '600'
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    padding: 10,
+    marginTop: 6
+  },
+  multiline: {
+    height: 80,
+    textAlignVertical: 'top'
+  },
+  rowWrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 8
+  },
+  chip: {
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    marginRight: 6,
+    marginBottom: 6
+  },
+  chipActive: {
+    backgroundColor: '#007aff',
+    borderColor: '#007aff'
+  },
+  chipText: {
+    color: '#333'
+  },
+  chipTextActive: {
+    color: '#fff'
+  },
+  button: {
+    backgroundColor: '#007aff',
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+    marginTop: 16
+  },
+  buttonDisabled: {
+    backgroundColor: '#9cc7ff'
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: '700'
+  },
+  error: {
+    color: '#c00',
+    marginTop: 10
+  },
+  resultContainer: {
+    marginTop: 20,
+    paddingVertical: 8
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700'
+  },
+  resultText: {
+    marginTop: 4
+  },
+  dayBlock: {
+    marginTop: 10,
+    padding: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#eee'
+  },
+  dayTitle: {
+    fontWeight: '700',
+    marginBottom: 6
+  },
+  mealText: {
+    marginTop: 2
+  }
+});

--- a/frontend/src/screens/MealPlannerScreen.jsx
+++ b/frontend/src/screens/MealPlannerScreen.jsx
@@ -28,6 +28,7 @@ export default function MealPlannerScreen() {
   const [error, setError] = useState('');
   const [result, setResult] = useState(null);
   const [testMode, setTestMode] = useState(false);
+  const [pingStatus, setPingStatus] = useState('');
 
   const canSubmit = useMemo(() => {
     return (
@@ -63,9 +64,32 @@ export default function MealPlannerScreen() {
     }
   };
 
+  const checkConnection = async () => {
+    try {
+      setPingStatus('Checking...');
+      const r = await fetch(`${API_URL}/health`);
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const j = await r.json();
+      setPingStatus(`OK (${j?.env || 'unknown'})`);
+    } catch (e) {
+      setPingStatus(`Failed: ${e?.message || 'error'}`);
+    }
+  };
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>Meal Planner</Text>
+      <Text style={styles.small}>API: {API_URL}</Text>
+      <View style={styles.testRow}>
+        <Text style={styles.label}>Test mode (skip AI)</Text>
+        <Switch value={testMode} onValueChange={setTestMode} />
+      </View>
+      <View style={[styles.testRow, { marginTop: 6 }]}>
+        <TouchableOpacity style={[styles.button, { paddingVertical: 10 }]} onPress={checkConnection}>
+          <Text style={styles.buttonText}>Check connection</Text>
+        </TouchableOpacity>
+        {!!pingStatus && <Text style={[styles.small, { marginLeft: 10 }]}>{pingStatus}</Text>}
+      </View>
 
       <Text style={styles.label}>Fitness Goal</Text>
       <View style={styles.rowWrap}>
@@ -293,5 +317,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between'
+  },
+  small: {
+    fontSize: 12,
+    color: '#666',
+    marginTop: 4
   }
 });

--- a/frontend/src/screens/MealPlannerScreen.jsx
+++ b/frontend/src/screens/MealPlannerScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator, ScrollView, Switch } from 'react-native';
 import API_URL from '../../config/config.js';
+import { useNavigation } from '@react-navigation/native';
 
 const goals = ['Weight Loss', 'Muscle Gain', 'Maintenance', 'General Health'];
 const genders = ['Male', 'Female', 'Other'];
@@ -13,6 +14,7 @@ const activityLevels = [
 ];
 
 export default function MealPlannerScreen() {
+  const navigation = useNavigation();
   const [form, setForm] = useState({
     fitnessGoal: 'General Health',
     heightCm: '',
@@ -208,8 +210,19 @@ export default function MealPlannerScreen() {
 
           <Text style={[styles.sectionTitle, { marginTop: 16 }]}>7-Day Plan</Text>
           {Object.entries(result.plan || {}).map(([day, meals]) => (
-            <View key={day} style={styles.dayBlock}>
-              <Text style={styles.dayTitle}>{String(day).toUpperCase()}</Text>
+            <TouchableOpacity
+              key={day}
+              style={styles.dayBlock}
+              onPress={() =>
+                navigation.navigate('Meal Plan Day', {
+                  dayKey: day,
+                  meals,
+                  calorieGoal: result.calorieGoal,
+                  macros: result.macros
+                })
+              }
+            >
+              <Text style={styles.dayTitle}>{String(day).toUpperCase()} (tap for details)</Text>
               {['breakfast', 'lunch', 'dinner'].map(mealKey => (
                 meals?.[mealKey] ? (
                   <Text key={mealKey} style={styles.mealText}>
@@ -220,7 +233,7 @@ export default function MealPlannerScreen() {
               {Array.isArray(meals?.snacks) && meals.snacks.length > 0 && (
                 <Text style={styles.mealText}>Snacks: {meals.snacks.join(', ')}</Text>
               )}
-            </View>
+            </TouchableOpacity>
           ))}
         </View>
       )}

--- a/frontend/src/screens/MealPlannerScreen.jsx
+++ b/frontend/src/screens/MealPlannerScreen.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator, ScrollView } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator, ScrollView, Switch } from 'react-native';
+import API_URL from '../../config/config.js';
 
 const goals = ['Weight Loss', 'Muscle Gain', 'Maintenance', 'General Health'];
 const genders = ['Male', 'Female', 'Other'];
@@ -10,8 +11,6 @@ const activityLevels = [
   'Very Active',
   'Extra Active'
 ];
-
-const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://10.200.237.49:5000';
 
 export default function MealPlannerScreen() {
   const [form, setForm] = useState({
@@ -28,6 +27,7 @@ export default function MealPlannerScreen() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [result, setResult] = useState(null);
+  const [testMode, setTestMode] = useState(false);
 
   const canSubmit = useMemo(() => {
     return (
@@ -44,7 +44,8 @@ export default function MealPlannerScreen() {
     setError('');
     setResult(null);
     try {
-      const res = await fetch(`${API_URL}/api/generate-meal-plan`, {
+      const qs = testMode ? '?test=1' : '';
+      const res = await fetch(`${API_URL}/api/generate-meal-plan${qs}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form)
@@ -153,6 +154,11 @@ export default function MealPlannerScreen() {
         placeholder="Dislikes, allergies"
         multiline
       />
+
+      <View style={styles.testRow}>
+        <Text style={styles.label}>Test mode (skip AI)</Text>
+        <Switch value={testMode} onValueChange={setTestMode} />
+      </View>
 
       <TouchableOpacity style={[styles.button, !canSubmit && styles.buttonDisabled]} disabled={!canSubmit || loading} onPress={submit}>
         {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.buttonText}>Generate Meal Plan</Text>}
@@ -281,5 +287,11 @@ const styles = StyleSheet.create({
   },
   mealText: {
     marginTop: 2
+  },
+  testRow: {
+    marginTop: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between'
   }
 });


### PR DESCRIPTION
# Summary

## Frontend

New MealPlannerScreen with form, test mode, and “Quick (1 day)” toggle
Nested “Meal Plan Day” screen with per-meal macros and “How to cook” steps
Stack navigation for Meal Planner; in-app health check; uses EXPO_PUBLIC_API_URL

## Backend

Endpoints: GET /, GET /health, POST /api/generate-meal-plan (query: test, days, model, timeoutMs), POST /api/recipe-instructions, POST /api/nutrition/estimate
CORS preflight + OpenAI timeout wrapper; refined prompt for simple, database-friendly names
Env (not committed)
Frontend: EXPO_PUBLIC_API_URL=http://YOUR_MACHINE_IP:5000
Backend: OPENAI_API_KEY, optional FATSECRET_CLIENT_ID/SECRET

## Test

Start backend, verify http://IP:5000/health
Restart Expo, open Meal Planner
Test mode → Generate (fast); then Quick (1 day) without test
Tap a day → see macros and cooking steps